### PR TITLE
remove mariadb dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,6 @@
 
 dependencies:
   - name: 'adfinis-sygroup.icinga2_agent'
-  - name: 'adfinis-sygroup.mariadb'
 
 galaxy_info:
   role_name: 'icinga2_master'


### PR DESCRIPTION
##### SUMMARY
the mariadb dependecy installs a mariadb server by default which is not needed if you use an external database like azure DB

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
