### PR TITLE
fix indentation of enable_ssl in ido configuration

### DIFF
--- a/templates/etc/icinga2/features-available/ido-mysql.conf.j2
+++ b/templates/etc/icinga2/features-available/ido-mysql.conf.j2
@@ -13,7 +13,7 @@ object IdoMysqlConnection "ido-mysql" {
   password = "{{ icinga2_master_icinga2_database_pass }}"
   host = "{{ icinga2_master_icinga2_database_host }}"
   database = "{{ icinga2_master_icinga2_database_name }}"
-  {% if icinga2_master_icinga2_database_ssl %}
+  {% if icinga2_master_icinga2_database_ssl -%}
   enable_ssl = true
   {% endif %}
 }


### PR DESCRIPTION
```
--- before: /etc/icinga2/features-available/ido-mysql.conf
+++ after: /etc/icinga2/features-available/ido-mysql.conf
@@ -13,5 +13,5 @@
   password = "YPSt5rPTC3dfY9SxsiSx6jVNL9mQagCy"
   host = "db-adsy-monitoring-prod-westeurope-1.mysql.database.azure.com"
   database = "icinga2"
-    enable_ssl = true
+  enable_ssl = true
   }
```