### PR TITLE
make procs Service configurable per host

### DIFF
--- a/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
+++ b/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
@@ -98,11 +98,13 @@ apply Service "load" {
   assign where (host.address || host.address6) && host.vars.os == "Linux"
 }
 
-apply Service "procs" {
+apply Service for (proc => config in host.vars.procs) {
   import "generic-service"
 
   check_command = "procs"
   command_endpoint = host.name
+
+  vars += config
 
   assign where host.vars.os == "Linux"
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

This change allows us to make the procs command configurable per host. Example config:
```c
  vars.procs["procs"] = {
    procs_warning = 512
    procs_critical = 1024
  }
  vars.procs["dockerd-current"] = {
    procs_command = "dockerd-current"
    procs_warning = "1:1"
    procs_critical = "1:1"
  }
```

This config piece monitors the process count with modified warning and critical values. It has also another section for checking if a docker process is running.