### PR TITLE
make the ununused conf files empty instead of deleting

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -47,9 +47,10 @@
   notify: icinga2_master reload icinga2
 
 - name: remove files from conf.d which are already defined in global-templates
-  file:
-    name: '{{ item }}'
-    state: absent
+  copy:
+    dest: '{{ item }}'
+    content: ""
+    force: yes
   loop:
     - /etc/icinga2/conf.d/services.conf
     - /etc/icinga2/conf.d/templates.conf


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This should help after upgrading icinga2 when the files are recreated from the package and icinga2 complains about doubled objects