### PR TITLE
services: imap, smtp, ldap and redis

### DIFF
--- a/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
+++ b/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
@@ -126,3 +126,43 @@ apply Service "users" {
 
   assign where host.vars.os == "Linux"
 }
+
+apply Service for (imap_host => config in host.vars.imap_hosts) {
+  import "generic-service"
+
+  check_command = "imap"
+
+  vars += config
+}
+
+apply Service for (smtp_host => config in host.vars.smtp_hosts) {
+  import "generic-service"
+
+  check_command = "smtp"
+
+  vars += config
+}
+
+apply Service for (ldap_host => config in host.vars.ldap_hosts) {
+  import "generic-service"
+
+  check_command = "ldap"
+
+  vars += config
+}
+
+apply Service for (mysql_host => config in host.vars.mysql_hosts) {
+  import "generic-service"
+
+  check_command = "mysql"
+
+  vars += config
+}
+
+apply Service for (redis_host => config in host.vars.redis_hosts) {
+  import "generic-service"
+
+  check_command = "redis"
+
+  vars += config
+}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This change implements the following new service apply rules:
* imap
* smtp
* ldap
* redis

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Below is an example on how to use these apply rules. The available variables can be taken from the official [icinga template library](https://icinga.com/docs/icinga2/latest/doc/10-icinga-template-library/#mysql).

```
icinga2_vars:
  - name: 'vars.imap_hosts["imaps"]'
    value: |
      {
          imap_port = 993
          imap_ssl = true
        }
  - name: 'vars.imap_hosts["imap"]'
    value: |
      {
          imap_port = 143
        }
```