### PR TITLE
Undefined variable.

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -35,8 +35,9 @@
     ssl_ca: '{{ icinga2_master_ca_path }}'
     state: import
     target: /usr/share/icinga2-ido-mysql/schema/mysql.sql
-  run_once: True
-  when: icinga2_master_register_icinga2_imported.rc == 1 and icinga2_master_ido_enabled
+  run_once: true
+  when: icinga2_master_ido_enabled and
+        icinga2_master_register_icinga2_imported.rc == 1
 
 - name: create a user with access only to the ido database using the root user
   mysql_user:
@@ -50,5 +51,6 @@
     login_password: '{{ icinga2_master_db_root_pass }}'
     ssl_ca: '{{ icinga2_master_ca_path }}'
     state: present
-  run_once: True
-  when: icinga2_master_register_icinga2_imported.rc == 1 and icinga2_master_ido_enabled
+  run_once: true
+  when: icinga2_master_ido_enabled and
+        icinga2_master_register_icinga2_imported.rc == 1


### PR DESCRIPTION
##### SUMMARY
icinga2_master_register_icinga2_imported.rc is not defined when icinga2_master_ido_enabled is set to false. So first check if this is set to true and after that evaluating the second variable is a good idea.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible 2.7.10
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/tr/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.3 (default, Mar 27 2019, 13:41:07) [GCC 8.3.1 20190223 (Red Hat 8.3.1-2)]
```