### PR TITLE
Add tcp/udp checks

### DIFF
--- a/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
+++ b/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
@@ -69,6 +69,16 @@ apply Service for (http_vhost => config in host.vars.http_vhosts) {
   assign where host.vars.check_http == true
 }
 
+apply Service for (tcp_check => config in host.vars.tcp_checks) {
+  import "generic-service"
+
+  check_command = "tcp"
+
+  vars += config
+
+  assign where host.vars.check_tcp == true
+}
+
 apply Service for (disk => config in host.vars.disks) {
   import "generic-service"
 

--- a/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
+++ b/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
@@ -79,6 +79,16 @@ apply Service for (tcp_check => config in host.vars.tcp_checks) {
   assign where host.vars.check_tcp == true
 }
 
+apply Service for (udp_check => config in host.vars.udp_checks) {
+  import "generic-service"
+
+  check_command = "udp"
+
+  vars += config
+
+  assign where host.vars.check_udp == true
+}
+
 apply Service for (disk => config in host.vars.disks) {
   import "generic-service"
 


### PR DESCRIPTION
##### SUMMARY
This change adds the necessary sections in `/etc/icinga2/zones.d/global-templates/services.conf` to apply the checks for `check_tcp` and `check_tcp`.

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.10
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/andi/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.3 (default, Mar 26 2019, 21:43:19) [GCC 8.2.1 20181127]
```


##### ADDITIONAL INFORMATION
Below is an example on how to use these apply rules. The available variables can be taken from the official [icinga template library](https://icinga.com/docs/icinga2/latest/doc/10-icinga-template-library/#tcp).
```
icinga2_vars:
  - name: 'vars.tcp_checks["tcp/8074 - Mattermost Gossip Port"]'
    value: |
      {
          tcp_port = 8074
        }
  - name: 'vars.tcp_checks["tcp/8075 - Mattermost HA Stream"]'
    value: |
      {
          tcp_port = 8075
        }
  - name: 'vars.udp_checks["udp/8074 - Mattermost Gossip Port"]'
    value: |
      {
          udp_port = 8074
        }
```
