### PR TITLE
add by_ssh check to global template

### DIFF
--- a/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
+++ b/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
@@ -57,7 +57,13 @@ apply Service "ssh" {
   assign where (host.address || host.address6) && host.vars.os == "Linux"
 }
 
+apply Service for (by_ssh => config in host.vars.by_ssh) {
+  import "generic-service"
 
+  check_command = "by_ssh"
+
+  vars += config
+}
 
 apply Service for (http_vhost => config in host.vars.http_vhosts) {
   import "generic-service"


### PR DESCRIPTION
##### SUMMARY
This change amends the [by_ssh](https://icinga.com/docs/icinga2/latest/doc/10-icinga-template-library/#by_ssh) check to the global template.

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
```
ansible 2.8.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/andi/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.3 (default, Mar 26 2019, 21:43:19) [GCC 8.2.1 20181127]
```