### PR TITLE
Update mechanics to support satellites which are not directly reachable

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -257,6 +257,21 @@
   loop: '{{ groups["monitoring-master"] }}'
   notify: icinga2_master reload icinga2
   when: inventory_hostname == icinga2_client_monitoring_parents[0]
+  
+- name: create host file per host for indirect satellites
+  template:
+    src: templates/etc/icinga2/zones.d/generic_host_without_ping.conf.j2
+    dest: '/etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}/{{ hostvars[item].inventory_hostname }}_host.conf'
+    owner: icinga
+    group: icinga
+    mode: 0640
+    seuser: system_u
+    serole: object_r
+    setype: etc_t
+    selevel: s0
+  loop: '{{ groups["monitoring-sat"] }}'
+  notify: icinga2_master reload icinga2
+  when: inventory_hostname == icinga2_client_monitoring_parents[0]
 
 - name: ensure that icinga2 is started and enabled on boot
   service:

--- a/templates/etc/icinga2/zones.d/generic_host_without_ping.conf.j2
+++ b/templates/etc/icinga2/zones.d/generic_host_without_ping.conf.j2
@@ -1,0 +1,27 @@
+/**
+ *  {{ ansible_managed }}
+ *  Configuration from Icinga2 version r2.10.2-1
+ */
+
+object Host "{{ hostvars[item].inventory_hostname }}" {
+  import "generic-host-without-ping"
+
+{% if hostvars[item].icinga2_master_client_address4 is defined %}
+  address = "{{ hostvars[item].icinga2_master_client_address4 }}"
+{% else%}
+  address = "{{ hostvars[item].inventory_hostname }}"
+{% endif %}
+{% if hostvars[item].icinga2_master_client_address6 is defined %}
+  address6 = "{{ hostvars[item].icinga2_master_client_address6 }}"
+{% endif %}
+
+  vars.client_endpoint = name
+  check_command = "icinga"
+
+{% if hostvars[item].icinga2_vars is defined %}
+{% for v in hostvars[item].icinga2_vars %}
+  vars.{{ v.name }} = {{ v.value }}
+{% endfor %}
+{% endif %}
+
+}

--- a/templates/etc/icinga2/zones.d/generic_host_without_ping.conf.j2
+++ b/templates/etc/icinga2/zones.d/generic_host_without_ping.conf.j2
@@ -4,7 +4,7 @@
  */
 
 object Host "{{ hostvars[item].inventory_hostname }}" {
-  import "generic-host-without-ping"
+  import "generic-host"
 
 {% if hostvars[item].icinga2_master_client_address4 is defined %}
   address = "{{ hostvars[item].icinga2_master_client_address4 }}"

--- a/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
+++ b/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
@@ -34,6 +34,7 @@ apply Service "ping4" {
   check_command = "ping4"
 
   assign where host.address
+  ignore where host.check_command == "icinga"
 }
 
 apply Service "ping6" {
@@ -42,6 +43,7 @@ apply Service "ping6" {
   check_command = "ping6"
 
   assign where host.address6
+  ignore where host.check_command == "icinga"
 }
 
 /*


### PR DESCRIPTION
I added mechanics to support satellites that are not reachable from the internet.
The playbook currently does create a satellite config that DOES work without reachability from outside but ping4, ping6 and check_command == "checkalive" does not work like that.

The commit changes check_command to "icinga" when the host is in the  [monitoring-sat] group.
Also, the service-template does not apply ping4 and ping6 checks to hosts with that setting anymore.

Commits will be squashed at merge.