### PR TITLE
implement check_command variable

### DIFF
--- a/templates/etc/icinga2/zones.d/generic_host.conf.j2
+++ b/templates/etc/icinga2/zones.d/generic_host.conf.j2
@@ -14,6 +14,9 @@ object Host "{{ hostvars[item].inventory_hostname }}" {
 {% if hostvars[item].icinga2_master_client_address6 is defined %}
   address6 = "{{ hostvars[item].icinga2_master_client_address6 }}"
 {% endif %}
+{% if hostvars[item].check_command is defined %}
+  check_command = "{{ hostvars[item].check_command }}"
+{% endif %}
 
   vars.client_endpoint = name
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This allows us to use other `check_commands` like `icinga2` or `dummy` if the host is not reachable through ICMP.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
