### PR TITLE
Fixxed the load check 

### DIFF
--- a/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
+++ b/templates/etc/icinga2/zones.d/global-templates/services.conf.j2
@@ -122,6 +122,13 @@ apply Service "load" {
 
   check_command = "load"
   command_endpoint = host.name
+  vars.load_percpu = true
+  vars.load_wload1 = "0.9"
+  vars.load_wload5 = "0.7"
+  vars.load_wload15 = "0.5"
+  vars.load_cload1 = "1.0"
+  vars.load_cload5 = "0.8"
+  vars.load_cload15 = "0.6"
 
   assign where (host.address || host.address6) && host.vars.os == "Linux"
 }


### PR DESCRIPTION
Changed load to percpu mechanism

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Changed load to percpu mechanism (Every host is a 1CPU Host, so a 0.90 load is 90% workload, so warning!)

##### ISSUE TYPE
 - Bugfix Pull Request


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
No additional information, dnsmichi
```
