### PR TITLE
feat(twilio_phone): allow application sid or application url

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ icinga2_master_twilio_phone_enabled: False
 # The twilio phone number used to make calls
 #icinga2_master_twilio_phone_from: '+41123456789'
 
-# The twilio application sid on how to handle the call
+# The twilio application on how to handle the call. You can either choose 
+# application sid or appication url. Choose only one. default is not defined.
 # https://www.twilio.com/docs/voice/make-calls
 #icinga2_master_twilio_phone_application_sid: 'application_sid'
+#icinga2_master_twilio_phone_application_url: 'application_url'
 ```
 
 Dependencies

--- a/templates/etc/icinga2/scripts/twilio-phone-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-phone-notification.sh.j2
@@ -11,7 +11,12 @@
 account_sid="{{ icinga2_master_twilio_account_sid }}"
 auth_token="{{ icinga2_master_twilio_auth_token }}"
 phone_number="{{ icinga2_master_twilio_phone_from }}"
-application_sid="{{ icinga2_master_twilio_phone_application_sid }}"
+{# Configure application sid or application url #}
+{% if icinga2_master_twilio_phone_application_sid is defined %}
+application="ApplicationSid={{ icinga2_master_twilio_phone_application_sid }}"
+{% elif icinga2_master_twilio_phone_application_url is defined %}
+application="Url={{ icinga2_master_twilio_phone_application_url }}"
+{% endif %}
 
 ## Function helpers
 Usage() {
@@ -66,6 +71,6 @@ echo "sent call to ${USERPHONE} now: $(date -u)" >> /var/log/icinga2/twilio.log
 
 curl -s -X POST -u "${account_sid}:${auth_token}" \
   https://api.twilio.com/2010-04-01/Accounts/"${account_sid}"/Calls.json \
-  --data-urlencode "ApplicationSid=${application_sid}" \
+  --data-urlencode "${application}" \
   --data-urlencode "To=${USERPHONE}" \
   --data-urlencode "From=${phone_number}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Currently, our setup generates a new error email as we do not have a TwiML application configured. Twilio has recently implement TwiML Bin which means we can now create TwiML application in their portal and do not have to self-host them. But these are only available through an url (as far as I understand it).


<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
