### PR TITLE
fix(ansible groups): groups names containing a dash (-) are invalid

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -207,7 +207,7 @@
     serole: object_r
     setype: etc_t
     selevel: s0
-  loop: '{{ groups["monitoring-client"] }}'
+  loop: '{{ groups["monitoring_client"] }}'
   notify: icinga2_master reload icinga2
   when: inventory_hostname == icinga2_client_monitoring_parents[0]
 
@@ -222,7 +222,7 @@
     serole: object_r
     setype: etc_t
     selevel: s0
-  loop: '{{ groups["monitoring-client"] }}'
+  loop: '{{ groups["monitoring_client"] }}'
   notify: icinga2_master reload icinga2
   when: inventory_hostname == icinga2_client_monitoring_parents[0]
 
@@ -237,7 +237,7 @@
     serole: object_r
     setype: etc_t
     selevel: s0
-  loop: '{{ groups["monitoring-client"] }}'
+  loop: '{{ groups["monitoring_client"] }}'
   notify: icinga2_master reload icinga2
   when: inventory_hostname == icinga2_client_monitoring_parents[0]
 
@@ -252,7 +252,7 @@
     serole: object_r
     setype: etc_t
     selevel: s0
-  loop: '{{ groups["monitoring-master"] }}'
+  loop: '{{ groups["monitoring_master"] }}'
   notify: icinga2_master reload icinga2
   when: inventory_hostname == icinga2_client_monitoring_parents[0]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->


In ansible 2.10, TRANSFORM_INVALID_GROUP_CHARS will change and not allow dashes in group names anymore

```
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in
group names by default, this will change, but still be user configurable on deprecation. This
feature will be removed in version 2.10.
```

BREAKING CHANGE: groups in the playbook must be renamed


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/fujexo/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.5 (default, Oct 17 2019, 12:16:48) [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]

```

