### PR TITLE
tasks/installation.yml: Don't use rc register field in check mode

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -24,6 +24,7 @@
   changed_when: icinga2_master_register_icinga2_imported.rc == 1
   failed_when: "'Access denied for' in icinga2_master_register_icinga2_imported.stderr"
   when: icinga2_master_ido_enabled|bool
+  check_mode: no
 
 - name: import icinga2 ido database schema using the root user
   mysql_db:


### PR DESCRIPTION
##### SUMMARY
In check mode, there is no task result to be stored in the register `icinga2_master_register_icinga2_imported`, so the `rc` field is missing. Subsequent checks that rely on the field existing therefore fail.

Since the same task sets the `changed` property if `rc` is 1, we can use that field instead, as it is guaranteed to exist, and we essentially perform the same check down the line.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/martinwe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.9 (default, Sep 25 2018, 20:42:16) [GCC 4.9.2]
```

##### ADDITIONAL INFORMATION
```
TASK [adfinis-sygroup.icinga2_master : import icinga2 ido database schema using the root user] ***************************
fatal: [foobar.example.com]: FAILED! => {"msg": "The conditional check 'icinga2_master_ido_enabled|bool and icinga2_master_register_icinga2_imported.rc == 1' failed. The error was: error while evaluating conditional (icinga2_master_ido_enabled|bool and icinga2_master_register_icinga2_imported.rc == 1): 'dict object' has no attribute 'rc'\n\nThe error appears to be in '/home/ayekat/adfinis-sygroup.icinga2_master/tasks/installation.yml': line 28, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: import icinga2 ido database schema using the root user\n  ^ here\n"}
```
