### PR TITLE
change configuration file owners for Debian

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -4,8 +4,8 @@
   template:
     src: etc/icinga2/features-available/ido-mysql.conf.j2
     dest: /etc/icinga2/features-available/ido-mysql.conf
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -24,8 +24,8 @@
   template:
     src: etc/icinga2/icinga2.conf.j2
     dest: /etc/icinga2/icinga2.conf
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -37,8 +37,8 @@
   template:
     src: etc/icinga2/constants.conf.j2
     dest: /etc/icinga2/constants.conf
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -60,8 +60,8 @@
   template:
     src: etc/icinga2/scripts/{{ item }}.j2
     dest: /etc/icinga2/scripts/{{ item }}
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0755
     seuser: system_u
     serole: object_r
@@ -76,8 +76,8 @@
   template:
     src: etc/icinga2/scripts/{{ item }}.j2
     dest: /etc/icinga2/scripts/{{ item }}
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0755
     seuser: system_u
     serole: object_r
@@ -91,8 +91,8 @@
   template:
     src: etc/icinga2/conf.d/{{ item }}.j2
     dest: /etc/icinga2/conf.d/{{ item }}
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -118,8 +118,8 @@
   template:
     src: etc/icinga2/features-available/api.conf.j2
     dest: /etc/icinga2/features-available/api.conf
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -136,8 +136,8 @@
   template:
     src: etc/icinga2/features-available/graphite.conf.j2
     dest: /etc/icinga2/features-available/graphite.conf
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -158,8 +158,8 @@
 - name: ensure the global-templates directory is present
   file:
     dest: /etc/icinga2/zones.d/global-templates
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0755
     seuser: system_u
     serole: object_r
@@ -172,8 +172,8 @@
   template:
     src: etc/icinga2/zones.d/global-templates/{{ item }}.j2
     dest: /etc/icinga2/zones.d/global-templates/{{ item }}
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -187,8 +187,8 @@
   template:
     src: etc/icinga2/zones.conf.j2
     dest: /etc/icinga2/zones.conf
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -200,8 +200,8 @@
   file:
     path: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}
     state: directory
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0755
     seuser: system_u
     serole: object_r
@@ -215,8 +215,8 @@
   template:
     src: etc/icinga2/zones.d/generic_zone.conf.j2
     dest: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}/{{ hostvars[item].inventory_hostname }}_zone.conf
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -230,8 +230,8 @@
   template:
     src: etc/icinga2/zones.d/generic_host.conf.j2
     dest: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}/{{ hostvars[item].inventory_hostname }}_host.conf
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -245,8 +245,8 @@
   template:
     src: etc/icinga2/zones.d/generic_host.conf.j2
     dest: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}/{{ hostvars[item].inventory_hostname }}_host.conf
-    owner: "{{ icinga2_user }}"
-    group: "{{ icinga2_group }}"
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -4,8 +4,8 @@
   template:
     src: etc/icinga2/features-available/ido-mysql.conf.j2
     dest: /etc/icinga2/features-available/ido-mysql.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -24,8 +24,8 @@
   template:
     src: etc/icinga2/icinga2.conf.j2
     dest: /etc/icinga2/icinga2.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -37,8 +37,8 @@
   template:
     src: etc/icinga2/constants.conf.j2
     dest: /etc/icinga2/constants.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -60,8 +60,8 @@
   template:
     src: etc/icinga2/scripts/{{ item }}.j2
     dest: /etc/icinga2/scripts/{{ item }}
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0755
     seuser: system_u
     serole: object_r
@@ -76,8 +76,8 @@
   template:
     src: etc/icinga2/scripts/{{ item }}.j2
     dest: /etc/icinga2/scripts/{{ item }}
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0755
     seuser: system_u
     serole: object_r
@@ -91,8 +91,8 @@
   template:
     src: etc/icinga2/conf.d/{{ item }}.j2
     dest: /etc/icinga2/conf.d/{{ item }}
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -118,8 +118,8 @@
   template:
     src: etc/icinga2/features-available/api.conf.j2
     dest: /etc/icinga2/features-available/api.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -136,8 +136,8 @@
   template:
     src: etc/icinga2/features-available/graphite.conf.j2
     dest: /etc/icinga2/features-available/graphite.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -158,8 +158,8 @@
 - name: ensure the global-templates directory is present
   file:
     dest: /etc/icinga2/zones.d/global-templates
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0755
     seuser: system_u
     serole: object_r
@@ -172,8 +172,8 @@
   template:
     src: etc/icinga2/zones.d/global-templates/{{ item }}.j2
     dest: /etc/icinga2/zones.d/global-templates/{{ item }}
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -187,8 +187,8 @@
   template:
     src: etc/icinga2/zones.conf.j2
     dest: /etc/icinga2/zones.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -200,8 +200,8 @@
   file:
     path: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}
     state: directory
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0755
     seuser: system_u
     serole: object_r
@@ -215,8 +215,8 @@
   template:
     src: etc/icinga2/zones.d/generic_zone.conf.j2
     dest: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}/{{ hostvars[item].inventory_hostname }}_zone.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -230,8 +230,8 @@
   template:
     src: etc/icinga2/zones.d/generic_host.conf.j2
     dest: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}/{{ hostvars[item].inventory_hostname }}_host.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r
@@ -245,8 +245,8 @@
   template:
     src: etc/icinga2/zones.d/generic_host.conf.j2
     dest: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}/{{ hostvars[item].inventory_hostname }}_host.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
     mode: 0640
     seuser: system_u
     serole: object_r

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,8 @@
 ---
 
+icinga2_user: "nagios"
+icinga2_group: "nagios"
+
 icinga2_master_ido_packages:
   - "python-mysqldb"
   - "icinga2-ido-mysql"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,7 @@
 ---
 
-icinga2_user: "nagios"
-icinga2_group: "nagios"
+icinga2_master_owner: "nagios"
+icinga2_master_group: "nagios"
 
 icinga2_master_ido_packages:
   - "python-mysqldb"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,7 +1,7 @@
 ---
 
-icinga2_user: "icinga"
-icinga2_group: "icinga"
+icinga2_master_owner: "icinga"
+icinga2_master_group: "icinga"
 
 icinga2_master_ido_packages:
   - "MySQL-python"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,8 @@
 ---
 
+icinga2_user: "icinga"
+icinga2_group: "icinga"
+
 icinga2_master_ido_packages:
   - "MySQL-python"
   - "icinga2-ido-mysql"


### PR DESCRIPTION
##### SUMMARY
This PR adds variables for Debian/RedHat to set the appropriate configuration file owner/group.
See also issue #72 .

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible 2.9.6
  config file = None
  configured module search path = ['/Users/christian/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/ansible
  executable location = /Library/Frameworks/Python.framework/Versions/3.8/bin/ansible
  python version = 3.8.2 (v3.8.2:7b3ab5921f, Feb 24 2020, 17:52:18) [Clang 6.0 (clang-600.0.57)]
```

##### ADDITIONAL INFORMATION
See also issue #72.

**Before change**
```
TASK [adfinis-sygroup.icinga2_master : install icinga2 configuration] ***************************************************************************************
fatal: [192.168.0.245]: FAILED! => {"changed": false, "checksum": "7952b01c49ff5f2250f3a3ded7458b522608500d", "gid": 116, "group": "icinga", "mode": "0640", "msg": "chown failed: failed to look up user icinga", "owner": "icinga", "path": "/etc/icinga2/icinga2.conf", "size": 1799, "state": "file", "uid": 111}
...
```

**After change**
```
TASK [adfinis-sygroup.icinga2_master : install icinga2 configuration] ***********************************************************************************
changed: [192.168.0.245]
```
