### PR TITLE
add missing templates (see also issue #74)

### DIFF
--- a/templates/etc/icinga2/conf.d/templates.conf.j2
+++ b/templates/etc/icinga2/conf.d/templates.conf.j2
@@ -2,8 +2,25 @@
  *  {{ ansible_managed }}
  *  Configuration from Icinga2 version r2.10.4
  *
- *  Icinga2 notification templates
+ *  Icinga2 templates
  */
+
+template Host "generic-host" {
+  max_check_attempts = 3
+  check_interval = 1m
+  retry_interval = 30s
+
+  check_command = "hostalive"
+}
+
+template Service "generic-service" {
+  max_check_attempts = 5
+  check_interval = 1m
+  retry_interval = 30s
+}
+
+template User "generic-user" {
+}
 
 template Notification "mail-host-notification" {
   command = "mail-host-notification"


### PR DESCRIPTION
##### SUMMARY
This PR adds missing basic templates for hosts, services and users.
These templates are part of the [upstream `templates.conf`](https://github.com/Icinga/icinga2/blob/master/etc/icinga2/conf.d/templates.conf).

This fixes issue #74.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.9.6
  config file = None
  configured module search path = ['/Users/christian/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/ansible
  executable location = /Library/Frameworks/Python.framework/Versions/3.8/bin/ansible
  python version = 3.8.2 (v3.8.2:7b3ab5921f, Feb 24 2020, 17:52:18) [Clang 6.0 (clang-600.0.57)]
```


##### ADDITIONAL INFORMATION
See also issue #74.

**Before**
```
RUNNING HANDLER [adfinis-sygroup.icinga2_master : icinga2_master reload icinga2] ****************************************************************************
fatal: [192.168.0.245]: FAILED! => {"changed": false, "msg": "Unable to reload service icinga2: Job for icinga2.service failed.\nSee \"systemctl status icinga2.service\" and \"journalctl -xe\" for details.\n"}
...
# icinga2 daemon -C
...
[2020-04-05 11:12:39 +0100] critical/config: Error: Import references unknown template: 'generic-user'
Location: in /etc/icinga2/conf.d/users.conf: 13:3-13:23
/etc/icinga2/conf.d/users.conf(11):
/etc/icinga2/conf.d/users.conf(12): object User "admin" {
/etc/icinga2/conf.d/users.conf(13):   import "generic-user"
                                      ^^^^^^^^^^^^^^^^^^^^^
```

After:
```
RUNNING HANDLER [adfinis-sygroup.icinga2_master : icinga2_master reload icinga2] ****************************************************************************
changed: [192.168.0.245]
```