### PR TITLE
Write satellite zone configs to global zones.conf

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -198,7 +198,7 @@
 
 - name: create zone configuration directory for each host
   file:
-    path: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}
+    path: /etc/icinga2/zones.d/{{ hostvars[item].inventory_hostname }}
     state: directory
     owner: "{{ icinga2_master_owner }}"
     group: "{{ icinga2_master_group }}"
@@ -207,7 +207,7 @@
     serole: object_r
     setype: etc_t
     selevel: s0
-  loop: '{{ groups["monitoring_client"] }}'
+  loop: '{{ groups["monitoring_sat"] }}'
   notify: icinga2_master reload icinga2
   when: inventory_hostname == icinga2_client_monitoring_parents[0]
 
@@ -224,7 +224,7 @@
     selevel: s0
   loop: '{{ groups["monitoring_client"] }}'
   notify: icinga2_master reload icinga2
-  when: inventory_hostname == icinga2_client_monitoring_parents[0]
+  when: inventory_hostname == icinga2_client_monitoring_parents[0] and hostvars[item].inventory_hostname not in groups["monitoring_sat"]
 
 - name: create host file per host
   template:

--- a/templates/etc/icinga2/zones.conf.j2
+++ b/templates/etc/icinga2/zones.conf.j2
@@ -27,3 +27,18 @@ object Zone "{{ icinga2_master_client_parent_zone }}" {
 object Zone "global-templates" {
   global = true
 }
+
+/*
+ * Satellite Zones
+ */
+{% for item in groups["monitoring_sat"] %}
+
+object Endpoint "{{ item }}" {
+}
+
+object Zone "{{ item }}" {
+  endpoints = [ "{{ item }}" ]
+
+  parent = "{{ icinga2_master_client_parent_zone }}"
+}
+{% endfor %}


### PR DESCRIPTION
##### SUMMARY
Write satellite zone configs to global zones.conf instead of writing them to a file within the parent's zones.d directory.

As described in https://github.com/Icinga/icinga2/issues/7530:
> 2.11 hardens the config sync thus only including directories in zones.d which have been configured outside in zones.conf.

The current configuration of satellites does not work anymore with icinga2 >= 2.11. To make this work satellite zones have to be defined in the global `zones.conf`.

##### ISSUE TYPE
 - Bugfix Pull Request


