### PR TITLE
Prevent icinga2 from attempting to connect to dummy hosts

### DIFF
--- a/templates/etc/icinga2/zones.d/generic_zone.conf.j2
+++ b/templates/etc/icinga2/zones.d/generic_zone.conf.j2
@@ -6,6 +6,7 @@
 object Endpoint "{{ hostvars[item].inventory_hostname }}" {
 {% if hostvars[item].icinga2_master_client_hostname is defined %}
   host = "{{ hostvars[item].icinga2_master_client_hostname }}"
+{% elif 'check_command' in hostvars[item] and hostvars[item].check_command == 'dummy' %}
 {% else %}
   host = name
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Prevent icinga2 from attempting to connect to dummy hosts
```
critical/ApiListener: Cannot connect to host 'foo.bar.example.com' on port '5665': Host not found (authoritative)
```

##### ISSUE TYPE
 - Bugfix Pull Request
