### PR TITLE
Set proper permissions for conf.d/services.conf & conf.d/hosts.conf

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -51,7 +51,7 @@
     dest: '{{ item }}'
     content: ""
     force: yes
-    mode: 0640
+    mode: 0644
   loop:
     - /etc/icinga2/conf.d/services.conf
     - /etc/icinga2/conf.d/hosts.conf


### PR DESCRIPTION
##### SUMMARY
Set proper permissions for conf.d/services.conf & conf.d/hosts.conf

##### ISSUE TYPE
 - Bugfix Pull Request

