### PR TITLE
Add downtimes.conf template

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ icinga2_master_api_users: []
 #  - username: token-generator
 #    password: 'passw0rd'
 #    permissions: 'actions/generate-ticket'
+
+# List of recurring downtimes
+icinga2_master_downtimes: []
+#  - name: web-restart
+#    comment: Web service restart every Monday and Thursday noon
+#    ranges:
+#      - day: monday
+#        time: 12:00-12:20
+#      - day: thursday
+#        time: 12:00-12:20
+#    hosts:
+#      - web.example.org
+#      - web2.example.org
+#    services:
+#      - svc_remote_http
+#      - svc_remote_https
+#      - svc_local_procs_apache2
 ```
 
 Templates can be adjusted using variables.
@@ -53,6 +70,7 @@ icinga2_master_template_confd_commands: "commands.conf"
 icinga2_master_template_confd_groups: "groups.conf"
 icinga2_master_template_confd_timeperiods: "timeperiods.conf"
 icinga2_master_template_confd_users: "users.conf"
+icinga2_master_template_confd_downtimes: "downtimes.conf"
 
 # These variables can be adjusted if you have custom templates for the global
 # templates directory which gets synced to all clients.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,6 +104,31 @@ icinga2_master_api_users: []
 #    - name: 'actions/generate-ticket'
 #      filter: '"host.name" == "bar"'
 
+# A list of all recurring Icinga2 downtimes
+icinga2_master_downtimes: []
+#  - name: web-restart
+#    comment: Nightly Web service restart
+#    ranges:
+#      - day: monday
+#        time: 01:00-01:30
+#      - day: tuesday
+#        time: 01:00-01:30
+#      - day: wednesday
+#        time: 01:00-01:30
+#      - day: thursday
+#        time: 01:00-01:30
+#      - day: friday
+#        time: 01:00-01:30
+#      - day: saturday
+#        time: 01:00-01:30
+#      - day: sunday
+#        time: 01:00-01:30
+#    hosts: ['host.example.org']
+#    services:
+#      - svc_remote_http
+#      - svc_remote_https
+#      - svc_local_procs_apache2
+
 # Icinga2 timeperiods
 icinga2_master_timeperiods:
   - name: holidays
@@ -198,6 +223,7 @@ icinga2_master_template_confd_commands: "commands.conf"
 icinga2_master_template_confd_groups: "groups.conf"
 icinga2_master_template_confd_timeperiods: "timeperiods.conf"
 icinga2_master_template_confd_users: "users.conf"
+icinga2_master_template_confd_downtimes: "downtimes.conf"
 
 # These variables can be adjusted if you have custom templates for the global
 # templates directory which gets synced to all clients.

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -107,6 +107,7 @@
     - "{{ icinga2_master_template_confd_groups }}"
     - "{{ icinga2_master_template_confd_timeperiods }}"
     - "{{ icinga2_master_template_confd_users }}"
+    - "{{ icinga2_master_template_confd_downtimes }}"
   notify: icinga2_master reload icinga2
 
 - name: execute icinga2 api setup command

--- a/templates/etc/icinga2/conf.d/downtimes.conf.j2
+++ b/templates/etc/icinga2/conf.d/downtimes.conf.j2
@@ -1,0 +1,24 @@
+/**
+ *  {{ ansible_managed }}
+ *  Configuration from Icinga2 version r2.10.4
+ *
+ *  Icinga2 service downtimes
+ */
+
+{% for downtime in icinga2_master_downtimes %}
+apply ScheduledDowntime "downtime-{{ downtime.name }}" to Service {
+  comment = "{{ downtime.comment }}"
+
+  ranges = {
+{% for range in downtime.ranges %}
+    "{{ range.day }}" = "{{ range.time }}"
+{% endfor %}
+  }
+
+  assign where host.name in [
+    "{{ downtime.hosts | join('",\n    "') }}"
+  ] && service.name in [
+    "{{ downtime.services | join('",\n    "') }}"
+  ]
+}
+{% endfor %}


### PR DESCRIPTION
##### SUMMARY

Icinga2 Director does not provide any functionality to set recurring downtimes, so modifying the configuration directly is necessary for this.

This allows setting downtimes for a given set of services on a given set of hosts.

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.9.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/{{user}}/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.16 (default, Oct 10 2019, 22:02:15) [GCC 8.3.0]
```