### PR TITLE
Allow downtimes to be set on hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ icinga2_master_api_users: []
 #    password: 'passw0rd'
 #    permissions: 'actions/generate-ticket'
 
-# List of recurring downtimes
+# List of recurring downtimes (undeclared/empty services == host downtime)
 icinga2_master_downtimes: []
 #  - name: web-restart
 #    comment: Web service restart every Monday and Thursday noon

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,30 +104,27 @@ icinga2_master_api_users: []
 #    - name: 'actions/generate-ticket'
 #      filter: '"host.name" == "bar"'
 
-# A list of all recurring Icinga2 downtimes
+# A list of all recurring Icinga2 host/service downtimes
 icinga2_master_downtimes: []
 #  - name: web-restart
-#    comment: Nightly Web service restart
+#    comment: Bi-weekly Web service restart
 #    ranges:
 #      - day: monday
 #        time: 01:00-01:30
-#      - day: tuesday
-#        time: 01:00-01:30
-#      - day: wednesday
-#        time: 01:00-01:30
 #      - day: thursday
-#        time: 01:00-01:30
-#      - day: friday
-#        time: 01:00-01:30
-#      - day: saturday
-#        time: 01:00-01:30
-#      - day: sunday
 #        time: 01:00-01:30
 #    hosts: ['host.example.org']
 #    services:
 #      - svc_remote_http
 #      - svc_remote_https
 #      - svc_local_procs_apache2
+#  - name: host-maintenance
+#    comment: Weekly host maintenance
+#    ranges:
+#      - day: wednesday
+#        time: 17:00-19:00
+#    hosts: ['host.example.org']
+#    # no services == applies to entire host
 
 # Icinga2 timeperiods
 icinga2_master_timeperiods:

--- a/templates/etc/icinga2/conf.d/downtimes.conf.j2
+++ b/templates/etc/icinga2/conf.d/downtimes.conf.j2
@@ -6,7 +6,7 @@
  */
 
 {% for downtime in icinga2_master_downtimes %}
-apply ScheduledDowntime "downtime-{{ downtime.name }}" to Service {
+apply ScheduledDowntime "downtime-{{ downtime.name }}" to {{ 'Service' if downtime.services else 'Host' }} {
   comment = "{{ downtime.comment }}"
 
   ranges = {
@@ -15,8 +15,8 @@ apply ScheduledDowntime "downtime-{{ downtime.name }}" to Service {
 
   assign where host.name in [
     "{{ downtime.hosts | join('",\n    "') }}"
-  ] && service.name in [
+  ]{% if downtime.services %} && service.name in [
     "{{ downtime.services | join('",\n    "') }}"
-  ]
+  ]{% endif %}
 }
 {% endfor %}

--- a/templates/etc/icinga2/conf.d/downtimes.conf.j2
+++ b/templates/etc/icinga2/conf.d/downtimes.conf.j2
@@ -10,10 +10,8 @@ apply ScheduledDowntime "downtime-{{ downtime.name }}" to Service {
   comment = "{{ downtime.comment }}"
 
   ranges = {
-{% for range in downtime.ranges %}
-    "{{ range.day }}" = "{{ range.time }}"
-{% endfor %}
-  }
+{% for range in downtime.ranges %}    "{{ range.day }}" = "{{ range.time }}"
+{% endfor %}  }
 
   assign where host.name in [
     "{{ downtime.hosts | join('",\n    "') }}"


### PR DESCRIPTION
##### SUMMARY

This is a follow-up to #95, to allow downtimes to be set on hosts, too.

The template is adapted to apply a downtime to `Host` instead of `Service` (and without any `where` clause for service names) if the `services:` attribute in a downtime specification is unset or empty.

See also [this example](https://community.icinga.com/t/schedule-downtimes-for-hosts/3472/2) for a reference.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.9.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/{{user}}/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.16 (default, Oct 10 2019, 22:02:15) [GCC 8.3.0]
```

##### ADDITIONAL INFORMATION

Not fully tested yet; but validity checked with Python and Jinja directly.