### PR TITLE
Put services in downtime also for full-host downtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ icinga2_master_api_users: []
 icinga2_master_downtimes: []
 #  - name: web-restart
 #    comment: Web service restart every Monday and Thursday noon
+#    author: icingaadmin
 #    ranges:
 #      - day: monday
 #        time: 12:00-12:20
@@ -58,6 +59,9 @@ icinga2_master_downtimes: []
 #      - svc_remote_http
 #      - svc_remote_https
 #      - svc_local_procs_apache2
+
+# Default downtimes author if downtime-specific author isn't set:
+icinga2_master_downtimes_author: icingaadmin
 ```
 
 Templates can be adjusted using variables.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ icinga2_master_api_users: []
 #    password: 'passw0rd'
 #    permissions: 'actions/generate-ticket'
 
-# List of recurring downtimes (undeclared/empty services == host downtime)
+# List of recurring downtimes
+# * `name`, `ranges` and `hosts` are mandatory.
+# * Unset/empty `services` results in full host downtimes.
+# * `day` and `time` in `ranges` follow the syntax of
+#   https://icinga.com/docs/icinga-2/latest/doc/08-advanced-topics/#time-periods
 icinga2_master_downtimes: []
 #  - name: web-restart
 #    comment: Web service restart every Monday and Thursday noon

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,6 +108,7 @@ icinga2_master_api_users: []
 icinga2_master_downtimes: []
 #  - name: web-restart
 #    comment: Bi-weekly Web service restart
+#    author: icingaadmin
 #    ranges:
 #      - day: monday
 #        time: 01:00-01:30
@@ -125,6 +126,7 @@ icinga2_master_downtimes: []
 #        time: 17:00-19:00
 #    hosts: ['host.example.org']
 #    # no services == applies to entire host
+icinga2_master_downtimes_author: icingaadmin
 
 # Icinga2 timeperiods
 icinga2_master_timeperiods:

--- a/templates/etc/icinga2/conf.d/downtimes.conf.j2
+++ b/templates/etc/icinga2/conf.d/downtimes.conf.j2
@@ -4,19 +4,37 @@
  *
  *  Icinga2 service downtimes
  */
-
 {% for downtime in icinga2_master_downtimes %}
-apply ScheduledDowntime "downtime-{{ downtime.name }}" to {{ 'Service' if downtime.services else 'Host' }} {
-  comment = "{{ downtime.comment }}"
 
+
+/* {{ downtime.comment | default(downtime.name) }} */
+
+template ScheduledDowntime "template-downtime-{{ downtime.name }}" {
   ranges = {
-{% for range in downtime.ranges %}    "{{ range.day }}" = "{{ range.time }}"
-{% endfor %}  }
+{% for range in downtime.ranges %}
+    "{{ range.day }}" = "{{ range.time }}"
+{% endfor %}
+  }
+}
 
+{% if not (downtime.services | default([])) %}
+apply ScheduledDowntime "host-downtime-{{ downtime.name }}" to Host {
+  import "template-downtime-{{ downtime.name }}"
+  comment = "{{ downtime.comment | default(downtime.name) }} (host downtime)"
   assign where host.name in [
     "{{ downtime.hosts | join('",\n    "') }}"
-  ]{% if downtime.services %} && service.name in [
+  ]
+}
+
+{% endif %}
+apply ScheduledDowntime "service-downtime-{{ downtime.name }}" to Service {
+  import "template-downtime-{{ downtime.name }}"
+  comment = "{{ downtime.comment | default(downtime.name) }} (service downtime)"
+  assign where host.name in [
+    "{{ downtime.hosts | join('",\n    "') }}"
+  ]{% if (downtime.services | default([])) %} && service.name in [
     "{{ downtime.services | join('",\n    "') }}"
   ]{% endif %}
+
 }
 {% endfor %}

--- a/templates/etc/icinga2/conf.d/downtimes.conf.j2
+++ b/templates/etc/icinga2/conf.d/downtimes.conf.j2
@@ -20,6 +20,7 @@ template ScheduledDowntime "template-downtime-{{ downtime.name }}" {
 {% if not (downtime.services | default([])) %}
 apply ScheduledDowntime "host-downtime-{{ downtime.name }}" to Host {
   import "template-downtime-{{ downtime.name }}"
+  author = "{{ downtime.author | default(icinga2_master_downtimes_author) }}"
   comment = "{{ downtime.comment | default(downtime.name) }} (host downtime)"
   assign where host.name in [
     "{{ downtime.hosts | join('",\n    "') }}"
@@ -29,6 +30,7 @@ apply ScheduledDowntime "host-downtime-{{ downtime.name }}" to Host {
 {% endif %}
 apply ScheduledDowntime "service-downtime-{{ downtime.name }}" to Service {
   import "template-downtime-{{ downtime.name }}"
+  author = "{{ downtime.author | default(icinga2_master_downtimes_author) }}"
   comment = "{{ downtime.comment | default(downtime.name) }} (service downtime)"
   assign where host.name in [
     "{{ downtime.hosts | join('",\n    "') }}"


### PR DESCRIPTION
##### SUMMARY

This is a follow-up to #96.

Merely applying a ScheduledDowntime to `Host` is not sufficient; one still also needs to put all of that host's services into a downtime.

These changes create the `apply … to Service` directive in all cases.
If setting a host downtime (empty `services` attribute), we additionally create an `apply … to Host` directive and leave out the service matching in the `where` clauses.

##### ISSUE TYPE

 - Bugfix Pull Request

##### ADDITIONAL INFORMATION

https://community.icinga.com/t/recuring-downtime-for-host-and-its-services/779

Template test in Python:

```
>>> ….render(icinga2_master_downtimes = [
    {'name': 'hoho',
     'comment': 'some random comment',
     'ranges': [{'day': 'monday', 'time': '01:00-02:00'},
                {'day': 'tuesday', 'time': '01:00-02:00'}],
     'hosts': ['hoho.tld'],
     'services': ['svc_a', 'svc_b']},
    {'name': 'hehe',
     'ranges': [{'day': 'wednesday', 'time': '12:00-12:05'}],
     'hosts': ['hoho.tld', 'hehe.tld']}]))
/**
 *  
 *  Configuration from Icinga2 version r2.10.4
 *
 *  Icinga2 service downtimes
 */


/* some random comment */

template ScheduledDowntime "template-downtime-hoho" {
  ranges = {
    "monday" = "01:00-02:00"
    "tuesday" = "01:00-02:00"
  }
}

apply ScheduledDowntime "service-downtime-hoho" to Service {
  import "template-downtime-hoho"
  comment = "some random comment (service downtime)"
  assign where host.name in [
    "hoho.tld"
  ] && service.name in [
    "svc_a",
    "svc_b"
  ]
}


/* hehe */

template ScheduledDowntime "template-downtime-hehe" {
  ranges = {
    "wednesday" = "12:00-12:05"
  }
}

apply ScheduledDowntime "host-downtime-hehe" to Host {
  import "template-downtime-hehe"
  comment = "hehe (host downtime)"
  assign where host.name in [
    "hoho.tld",
    "hehe.tld"
  ]
}

apply ScheduledDowntime "service-downtime-hehe" to Service {
  import "template-downtime-hehe"
  comment = "hehe (service downtime)"
  assign where host.name in [
    "hoho.tld",
    "hehe.tld"
  ]
}
```
