### PR TITLE
WIP: Implement option to send the notification to a mattermost channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,27 @@ icinga2_master_twilio_phone_enabled: False
 # https://www.twilio.com/docs/voice/make-calls
 #icinga2_master_twilio_phone_application_sid: 'application_sid'
 #icinga2_master_twilio_phone_application_url: 'application_url'
+
+# Wether to enable SMS to Mattermost notifications
+# This requires an incoming mattermost webhook to be configured in your
+# mattermost instance. See https://docs.mattermost.com/developer/webhooks-incoming.html
+
+# Enable the sms to mattermost notification
+icinga2_master_sms_to_mattermost_notification: False
+
+# Which channel to send the post to
+icinga2_master_notification_mattermost_channel: alerts
+
+# Username of the Bot posting the message
+icinga2_master_notification_mattermost_username: Alertbot
+
+# Profile picture of the bot posting the message
+# Can be left empty (the default of the webhook will be used or point to an image file
+icinga2_master_notification_mattermost_icon_url: ""
+
+# The webhook where to send the message to
+icinga2_master_notification_mattermost_webhook: "https://mattermost.example.com/hooks/hookid"
+
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -246,3 +246,23 @@ icinga2_master_twilio_phone_enabled: False
 # Example:
 # icinga2_master_twilio_shorturl_cmd: "curl -s -X POST https://urlshort.example.com/api/new -d url=${LONGURL} | jq -r .shorturl"
 icinga2_master_twilio_shorturl_cmd: ""
+
+# Wether to enable SMS to Mattermost notifications
+# This requires an incoming mattermost webhook to be configured in your
+# mattermost instance. See https://docs.mattermost.com/developer/webhooks-incoming.html
+
+# Enable the sms to mattermost notification
+icinga2_master_sms_to_mattermost_notification: False
+
+# Which channel to send the post to
+icinga2_master_notification_mattermost_channel: alerts
+
+# Username of the Bot posting the message
+icinga2_master_notification_mattermost_username: Alertbot
+
+# Profile picture of the bot posting the message
+# Can be left empty (the default of the webhook will be used or point to an image file
+icinga2_master_notification_mattermost_icon_url: ""
+
+# The webhook where to send the message to
+icinga2_master_notification_mattermost_webhook: "https://mattermost.example.com/hooks/hookid"

--- a/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
@@ -123,6 +123,16 @@ if [ "$VERBOSE" == "true" ] ; then
   logger "$PROG sends $SUBJECT => $USERPHONE"
 fi
 
+{% if icinga2_master_sms_to_mattermost_notification is defined and icinga2_master_sms_to_mattermost_notification %}
+MM_MSG=$(cat << EOF
+{"channel": "{{ icinga2_master_notification_mattermost_channel }}", "username": "{{ icinga2_master_notification_mattermost_username }}", "icon_url": "{{ icinga2_master_notification_mattermost_icon_url }}", "text": "${NOTIFICATION_MESSAGE}"}
+EOF
+)
+
+curl -s -X POST -H 'Content-Type: application/json' \
+  -d "${MM_MSG}" \
+  {{ icinga2_master_notification_mattermost_webhook }} > /dev/null
+{% endif %}
 
 ## Send the sms using the Twilio API
 echo "sent sms to ${phone_number} now: $(date -u)" >> /var/log/icinga2/twilio.log

--- a/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
@@ -130,6 +130,16 @@ if [ "$VERBOSE" == "true" ] ; then
   logger "$PROG sends $SUBJECT => $USERPHONE"
 fi
 
+{% if icinga2_master_sms_to_mattermost_notification is defined and icinga2_master_sms_to_mattermost_notification %}
+MM_MSG=$(cat << EOF
+{"channel": "{{ icinga2_master_notification_mattermost_channel }}", "username": "{{ icinga2_master_notification_mattermost_username }}", "icon_url": "{{ icinga2_master_notification_mattermost_icon_url }}", "text": "${NOTIFICATION_MESSAGE}"}
+EOF
+)
+
+curl -s -X POST -H 'Content-Type: application/json' \
+  -d "${MM_MSG}" \
+  {{ icinga2_master_notification_mattermost_webhook }} > /dev/null
+{% endif %}
 
 ## Send the call using the Twilio API
 echo "sent sms to ${phone_number} now: $(date -u)" >> /var/log/icinga2/twilio.log


### PR DESCRIPTION
##### SUMMARY

Long SMS may be delayed by twilio (Depends on the receiving provider and
message lenght, multi-segement SMS are more prone to be delayed).

This option gives us the ability to also send the notifications to a
configurable mattermost channel and allows the on-call member to check
this channel if he didn't receive an sms with the host or service
alerting.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


