### PR TITLE
implement short url capability

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,33 +14,33 @@ icinga2_master_users:
     email: 'alertme@example.com'
     groups:
       - icingaadmins
-#icinga2_master_users:
-#  - name: username
-#    displayname: 'User Name' # optional, defaults to an empty string
-#    email: 'mail@example.com' # optional, defaults to an empty string
-#    pager: '+41123456789' # optional, defaults to an empty string
-#    groups: [] # optional, defaults to an empty list
-#      # - group1
-#      # - group2
-#    enable_notifications: (true|false) # optional, defaults to true
-#    period: '24x7' # optional, not set by default
-#    types: [] # optional, not set by default
-#      # - DowntimeStart
-#      # - DowntimeEnd
-#      # - DowntimeRemoved
-#      # - Custom
-#      # - Acknowledgement
-#      # - Problem
-#      # - Recovery
-#      # - FlappingStart
-#      # - FlappingEnd
-#    states: [] # optional, not set by default
-#      # - OK
-#      # - Warning
-#      # - Critical
-#      # - Unknown
-#      # - Up
-#      # - Down
+# icinga2_master_users:
+#   - name: username
+#     displayname: 'User Name' # optional, defaults to an empty string
+#     email: 'mail@example.com' # optional, defaults to an empty string
+#     pager: '+41123456789' # optional, defaults to an empty string
+#     groups: [] # optional, defaults to an empty list
+#       # - group1
+#       # - group2
+#     enable_notifications: (true|false) # optional, defaults to true
+#     period: '24x7' # optional, not set by default
+#     types: [] # optional, not set by default
+#       # - DowntimeStart
+#       # - DowntimeEnd
+#       # - DowntimeRemoved
+#       # - Custom
+#       # - Acknowledgement
+#       # - Problem
+#       # - Recovery
+#       # - FlappingStart
+#       # - FlappingEnd
+#     states: [] # optional, not set by default
+#       # - OK
+#       # - Warning
+#       # - Critical
+#       # - Unknown
+#       # - Up
+#       # - Down
 
 # All groups which icinga2 should know.
 # Check the official icinga2 documentation for further information
@@ -48,45 +48,45 @@ icinga2_master_users:
 icinga2_master_usergroups:
   - name: icingaadmins
     displayname: 'Icinga2 Admins'
-#icinga2_master_usergroups:
-#  - name: groupname
-#    displayname: 'Group Name' # optional, defaults to an empty string
-#    groups: [] # optional, not set by default
-#      # - group1
-#      # - group2
+# icinga2_master_usergroups:
+#   - name: groupname
+#     displayname: 'Group Name' # optional, defaults to an empty string
+#     groups: [] # optional, not set by default
+#       # - group1
+#       # - group2
 
 # Icinga2 Hostgroups
 icinga2_master_hostgroups: []
-#icinga2_master_hostgroups:
-#  - name: linux-servers
-#    display_name: 'Linux Servers'
-#    assignments:
-#      - var: 'host.vars.os'
-#        value: 'Linux'
-#  - name: windows-servers
-#    display_name: 'Windows Servers'
-#    assignments:
-#      - var: 'host.vars.os'
-#        value: 'Windows'
+# icinga2_master_hostgroups:
+#   - name: linux-servers
+#     display_name: 'Linux Servers'
+#     assignments:
+#       - var: 'host.vars.os'
+#         value: 'Linux'
+#   - name: windows-servers
+#     display_name: 'Windows Servers'
+#     assignments:
+#       - var: 'host.vars.os'
+#         value: 'Windows'
 
 # Icinga2 ServiceGroups
 icinga2_master_servicegroups: []
-#icinga2_master_servicegroups:
-#  - name: ping
-#    display_name: 'Ping Checks'
-#    assignments:
-#      - match: 'ping*'
-#        value: 'service.name'
-#  - name: http
-#    display_name: 'HTTP Checks'
-#    assignments:
-#      - match: 'http*'
-#        value: 'service.check_command'
-#  - name: disk
-#    display_name: 'Disk Checks'
-#    assignments:
-#      - match: 'disk*'
-#        value: 'service.check_command'
+# icinga2_master_servicegroups:
+#   - name: ping
+#     display_name: 'Ping Checks'
+#     assignments:
+#       - match: 'ping*'
+#         value: 'service.name'
+#   - name: http
+#     display_name: 'HTTP Checks'
+#     assignments:
+#       - match: 'http*'
+#         value: 'service.check_command'
+#   - name: disk
+#     display_name: 'Disk Checks'
+#     assignments:
+#       - match: 'disk*'
+#         value: 'service.check_command'
 
 # A list of all icinga2 api users
 icinga2_master_api_users: []
@@ -212,31 +212,37 @@ icinga2_master_global_zones:
 ## Global alerting settings
 
 # The URL from icingaweb2. Will be attached to the alerts
-#icinga2_master_alerting_icingaweb2url = "https://icinga2.example.com/icingaweb2"
+# icinga2_master_alerting_icingaweb2url = "https://icinga2.example.com/icingaweb2"
 
 # The adress from which mails should be sent
-#icinga2_master_mail_from: "mail@example.com"
+# icinga2_master_mail_from: "mail@example.com"
 
 ## Twilio alerting
 
 # The account sid from https://www.twilio.com/console
-#icinga2_master_twilio_account_sid: 'account_sid'
+# icinga2_master_twilio_account_sid: 'account_sid'
 
 # The auth token from https://www.twilio.com/console
-#icinga2_master_twilio_auth_token: 'auth_token'
+# icinga2_master_twilio_auth_token: 'auth_token'
 
 # Whether twilio sms are enabled or not
 icinga2_master_twilio_sms_enabled: False
 
 # The twilio phone numer used to send sms
-#icinga2_master_twilio_sms_from: '+41123456789'
+# icinga2_master_twilio_sms_from: '+41123456789'
 
 # Whether twilio calls are enabled or not
 icinga2_master_twilio_phone_enabled: False
 
 # The twilio phone number used to make calls
-#icinga2_master_twilio_phone_from: '+41123456789'
+# icinga2_master_twilio_phone_from: '+41123456789'
 
 # The twilio application sid on how to handle the call
 # https://www.twilio.com/docs/voice/make-calls
-#icinga2_master_twilio_phone_application_sid: 'application_sid'
+# icinga2_master_twilio_phone_application_sid: 'application_sid'
+
+# Icinga2 shorturl cmd
+# The command which gets substituted when this variable is set
+# Example:
+# icinga2_master_twilio_shorturl_cmd: "curl -s -X POST https://urlshort.example.com/api/new -d url=${LONGURL} | jq -r .shorturl"
+icinga2_master_twilio_shorturl_cmd: ""

--- a/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
@@ -108,9 +108,16 @@ EOF
 
 ## Check whether Icinga Web 2 URL was specified.
 if [ -n "$ICINGAWEB2URL" ] ; then
-  NOTIFICATION_MESSAGE="$NOTIFICATION_MESSAGE
+  LONGURL="${ICINGAWEB2URL}/monitoring/service/show?host=$(urlencode "${HOSTNAME}&")service=$(urlencode "${SERVICENAME}")"
+  SHORTURL=$({{ icinga2_master_twilio_shorturl_cmd }})
 
-$ICINGAWEB2URL/monitoring/host/show?host=$(urlencode "$HOSTNAME")"
+  if [ ! -z ${SHORTURL} ]; then
+    NOTIFICATION_MESSAGE="$NOTIFICATION_MESSAGE
+${SHORTURL}"
+  else
+    NOTIFICATION_MESSAGE="$NOTIFICATION_MESSAGE
+${LONGURL}"
+  fi
 fi
 
 ## Check whether verbose mode was enabled and log to syslog.

--- a/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
@@ -111,9 +111,16 @@ EOF
 
 ## Check whether Icinga Web 2 URL was specified.
 if [ -n "$ICINGAWEB2URL" ] ; then
-  NOTIFICATION_MESSAGE="$NOTIFICATION_MESSAGE
+  LONGURL="${ICINGAWEB2URL}/monitoring/service/show?host=$(urlencode "${HOSTNAME}&")service=$(urlencode "${SERVICENAME}")"
+  SHORTURL=$({{ icinga2_master_twilio_shorturl_cmd }})
 
-$ICINGAWEB2URL/monitoring/service/show?host=$(urlencode "$HOSTNAME")&service=$(urlencode "$SERVICENAME")"
+  if [ ! -z ${SHORTURL} ]; then
+    NOTIFICATION_MESSAGE="$NOTIFICATION_MESSAGE
+${SHORTURL}"
+  else
+    NOTIFICATION_MESSAGE="$NOTIFICATION_MESSAGE
+${LONGURL}"
+  fi
 fi
 
 ## Check whether verbose mode was enabled and log to syslog.


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This commit allows users of the twilio sms feature to configure a
short url command which shortens the sms quite drastically.

For simplicity, the shorturl is configured trough an ansible variable
containing the command which gets the shortened url. There is probably
a nicer way to do this, but this was quite quick and easy and just works.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request