### PR TITLE
fix(ansible-lint): action with ansible 2.10 and lint 5.0

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           targets: icinga2_master
           args: "-R -r lint-rules"
+          override-deps: |
+            ansible~=2.10
+            ansible-lint~=5.0
 
       - name: yamllint
         uses: karancode/yamllint-github-action@v2.0.0


### PR DESCRIPTION
Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

The GH Action isn't working anymore. We saw this happening on other projects due to this PR on our ansible lint rules:

https://github.com/adfinis-sygroup/ansible-lint-rules/pull/4
https://github.com/adfinis-sygroup/ansible-lint-rules/pull/3

The rules now need ansible~=2.10 and ansible-lint ~=5.0

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.10
lint 5.0.0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
