### PR TITLE
Fix debian support

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -249,6 +249,24 @@
       inventory_hostname == icinga2_client_monitoring_parents[0]
       and not ('icinga2_client_director_managed' in hostvars[item] and hostvars[item].icinga2_client_director_managed)
 
+# @TODO: icinga2_master_client_parent_zone is not being created if no satelitte is being used THIS IS A WORKAROUND!
+- name: create master zone
+  file:
+    path: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}/
+    owner: "{{ icinga2_master_owner }}"
+    group: "{{ icinga2_master_group }}"
+    mode: 0640
+    seuser: system_u
+    serole: object_r
+    setype: icinga2_etc_t
+    selevel: s0
+    state: directory
+  loop: '{{ groups["monitoring_master"] }}'
+  notify: icinga2_master reload icinga2
+  when: inventory_hostname == icinga2_client_monitoring_parents[0]
+        and not ('icinga2_client_director_managed' in hostvars[item] and hostvars[item].icinga2_client_director_managed)
+
+
 - name: add our own host configuration
   template:
     src: etc/icinga2/zones.d/generic_host.conf.j2

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -249,8 +249,7 @@
       inventory_hostname == icinga2_client_monitoring_parents[0]
       and not ('icinga2_client_director_managed' in hostvars[item] and hostvars[item].icinga2_client_director_managed)
 
-# @TODO: icinga2_master_client_parent_zone is not being created if no satelitte is being used THIS IS A WORKAROUND!
-- name: create master zone
+- name: ensure master zone folder exists
   file:
     path: /etc/icinga2/zones.d/{{ hostvars[item].icinga2_master_client_parent_zone }}/
     owner: "{{ icinga2_master_owner }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,6 +6,6 @@ icinga2_master_group: "nagios"
 icinga2_master_ido_packages:
   - "python-mysqldb"
   - "icinga2-ido-mysql"
-  - "mariadb-client"
+  - "default-mysql-client"
 
 icinga2_master_ca_path: "/etc/ssl/certs/ca-certificates.crt"

--- a/vars/Debian_11.yml
+++ b/vars/Debian_11.yml
@@ -6,6 +6,6 @@ icinga2_master_group: "nagios"
 icinga2_master_ido_packages:
   - "python-mysqldb"
   - "icinga2-ido-mysql"
-  - "mysql-client"
+  - "mariadb-client"
 
 icinga2_master_ca_path: "/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
##### SUMMARY

* use default-mysql-client to provide either mysql-client or mariadb-client instead of directly using mysql-client
  * This could make it incompatible on ubuntu, maybe
* Provide a small fix so the folder for the icinga2_master_client_parent_zone  is always created
  * The issue is in ansible itself, ansible cant set the selinux content when the directory does not already exist.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible [core 2.11.1]
```
