### PR TITLE
Add github actions workflow to publish role to ansible galaxy

### DIFF
--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -1,0 +1,18 @@
+---
+name: Publish on Ansible Galaxy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: galaxy
+        uses: robertdebock/galaxy-action@1.1.0
+        with:
+          galaxy_api_key: ${{ secrets.galaxy_api_key }}


### PR DESCRIPTION
##### SUMMARY
Add github actions workflow to publish role to ansible galaxy
